### PR TITLE
Add interact examples for OIDC Credential Provider and DIDCommv2

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,6 +392,26 @@ interface, for example, a person using a Web browser.
       </section>
 
       <section>
+        <h3>OIDC Credential Provider</h3>
+
+        <p>
+A mediated presentation service that utilizes the Open ID Connect Credential
+Provider interaction mechanism.
+        </p>
+
+        <pre class="example nohighlight" title="A mediated presentation service that uses a Web browser">
+...
+"interact": {
+  "service": [{
+    "type": "OpenIdConnectCredentialProviderService2021",
+    "serviceEndpoint": "https://degree.example/authorize?response_type=code&scope=openid%20openid_credential&client_id=s6BhdRkqt3&state=af0ifjsldkj&redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb&credential_format=w3cvc-jsonld"
+  }]
+}
+...
+        </pre>
+      </section>
+
+      <section>
         <h3>Unmediated Presentation</h3>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -399,7 +399,7 @@ A mediated presentation service that utilizes the Open ID Connect Credential
 Provider interaction mechanism.
         </p>
 
-        <pre class="example nohighlight" title="A mediated presentation service that uses a Web browser">
+        <pre class="example nohighlight" title="A mediated presentation service that uses the OpenID Connect Credential Provider protocol">
 ...
 "interact": {
   "service": [{
@@ -419,7 +419,7 @@ A mediated presentation service that utilizes the DIDCommv2 interaction
 mechanism.
         </p>
 
-        <pre class="example nohighlight" title="A mediated presentation service that uses a Web browser">
+        <pre class="example nohighlight" title="A mediated presentation service that uses the DIDComm v2 Messaging protocol">
 ...
 "interact": {
   "service": [{

--- a/index.html
+++ b/index.html
@@ -412,6 +412,32 @@ Provider interaction mechanism.
       </section>
 
       <section>
+        <h3>DIDCommv2 Presentation</h3>
+
+        <p>
+A mediated presentation service that utilizes the DIDCommv2 interaction
+mechanism.
+        </p>
+
+        <pre class="example nohighlight" title="A mediated presentation service that uses a Web browser">
+...
+"interact": {
+  "service": [{
+    "id": "did:example:123456789abcdefghi#didcomm-1",
+    "type": "DIDCommMessaging",
+    "serviceEndpoint": "http://example.com/path",
+    "accept": [
+       "didcomm/v2",
+       "didcomm/aip2;env=rfc587"
+     ],
+     "routingKeys": ["did:example:somemediator#somekey"]
+  }]
+}
+...
+        </pre>
+      </section>
+
+      <section>
         <h3>Unmediated Presentation</h3>
 
         <p>


### PR DESCRIPTION
This PR builds on PR #13 and adds alternate interaction mechanisms for Verifiable Presentation Requests. The addition of interact examples for OIDC Credential Provider and DIDCommv2 demonstrates how different interaction protocols can be bootstrapped into, and chained together, from a Verifiable Presentation Request.

These interaction patterns are designed to be used in flows such as those described in the VC API spec:

![image](https://user-images.githubusercontent.com/108611/149668855-7896413d-a117-45ca-b4e7-aec0ea9534a4.png)

Example messages that utilize `interact` in a VC API flow are provided here:

https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-api/pull/255.html#example-step-1-request-to-issuer-initiate-degree-refresh-workflow


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vp-request-spec/pull/15.html" title="Last updated on Jan 16, 2022, 7:49 PM UTC (5e202c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vp-request-spec/15/3d65054...5e202c7.html" title="Last updated on Jan 16, 2022, 7:49 PM UTC (5e202c7)">Diff</a>