### PR TITLE
Fix DIDComm service

### DIFF
--- a/index.html
+++ b/index.html
@@ -631,12 +631,14 @@ mechanism.
   "service": [{
     "id": "did:example:123456789abcdefghi#didcomm-1",
     "type": "DIDCommMessaging",
-    "serviceEndpoint": "http://example.com/path",
-    "accept": [
-       "didcomm/v2",
-       "didcomm/aip2;env=rfc587"
-     ],
-     "routingKeys": ["did:example:somemediator#somekey"]
+    "serviceEndpoint": {
+      "uri": "http://example.com/path",
+      "accept": [
+        "didcomm/v2",
+        "didcomm/aip2;env=rfc587"
+      ],
+      "routingKeys": ["did:example:somemediator#somekey"]
+    }
   }]
 }
 ...


### PR DESCRIPTION
DIDComm spec changed to an object for `serviceEndpoint`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brianorwhatever/vp-request-spec/pull/26.html" title="Last updated on Jul 28, 2023, 10:33 PM UTC (bfd9027)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vp-request-spec/26/d47686a...brianorwhatever:bfd9027.html" title="Last updated on Jul 28, 2023, 10:33 PM UTC (bfd9027)">Diff</a>