### PR TITLE
Update zCap example to controller, etc.

### DIFF
--- a/index.html
+++ b/index.html
@@ -608,7 +608,7 @@ Capabilities or "zcaps" in the Verifiable Presentation.
       allowedAction: 'sign',
       controller: 'did:key:1234',
       invocationTarget: {
-        type: 'Ed25519VerificationKey2018',
+        type: 'Ed25519VerificationKey2020',
         proofPurpose: 'assertionMethod'
       }
     }, {

--- a/index.html
+++ b/index.html
@@ -585,7 +585,7 @@ The example below demonstrates a simple DID Authentication response.
       </section>
 
       <section>
-        <h3>Authorization Capability Request</h3>
+        <h2>Authorization Capability Request</h2>
 
         <p>
 This query type would be included in a request to ask for Authorization
@@ -599,20 +599,23 @@ Capabilities or "zcaps" in the Verifiable Presentation.
     capabilityQuery: [{
       referenceId: `a-memorable-name`,
       allowedAction: ['read', 'write'],
-      invoker: 'did:key:1234',
-      delegator: 'did:key:1234'
+      controller: 'did:key:1234'
       invocationTarget: {
         type: 'urn:edv:documents'
       }
     }, {
-      referenceId: `another-memorable-name`,
+      referenceId: `a-sign-request`,
       allowedAction: 'sign',
-      invoker: 'did:key:1234',
-      delegator: 'did:key:1234',
+      controller: 'did:key:1234',
       invocationTarget: {
         type: 'Ed25519VerificationKey2018',
         proofPurpose: 'assertionMethod'
       }
+    }, {
+      referenceId: `another-memorable-name`,
+      allowedAction: 'POST',
+      controller: 'did:key:1234',
+      invocationTarget: "https://example.com/api/endpoint"
     }],
     challenge: '111112b24-63d9-11ea-b99f-4f66f3e4f81a'
   }]

--- a/index.html
+++ b/index.html
@@ -597,14 +597,14 @@ Capabilities or "zcaps" in the Verifiable Presentation.
   query: [{
     type: 'ZcapQuery',
     capabilityQuery: [{
-      referenceId: `a-memorable-name`,
+      referenceId: `a-memorable-semantic-name-about-the-zcap`,
       allowedAction: ['read', 'write'],
       controller: 'did:key:1234'
       invocationTarget: {
         type: 'urn:edv:documents'
       }
     }, {
-      referenceId: `a-sign-request`,
+      referenceId: `a-zcap-for-signing-credentials`,
       allowedAction: 'sign',
       controller: 'did:key:1234',
       invocationTarget: {
@@ -612,7 +612,7 @@ Capabilities or "zcaps" in the Verifiable Presentation.
         proofPurpose: 'assertionMethod'
       }
     }, {
-      referenceId: `another-memorable-name`,
+      referenceId: `forPostingAnExample`,
       allowedAction: 'POST',
       controller: 'did:key:1234',
       invocationTarget: "https://example.com/api/endpoint"


### PR DESCRIPTION
Addresses issue #41.

* Changes the "Authorization Capability Request" to `<h2>` so that it appears in the Table of Contents.
* Updates the example to use `controller` instead of the obsolete `invoker` etc.
* Adds a third zcap query to the example (of just invoking an http api endpoint).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vp-request-spec/pull/43.html" title="Last updated on Sep 1, 2025, 10:08 PM UTC (f7d7dba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vp-request-spec/43/a9e8553...f7d7dba.html" title="Last updated on Sep 1, 2025, 10:08 PM UTC (f7d7dba)">Diff</a>